### PR TITLE
FIX: import specific `skimage` modules

### DIFF
--- a/nobrainer/cli/main.py
+++ b/nobrainer/cli/main.py
@@ -10,7 +10,8 @@ import sys
 import click
 import nibabel as nib
 import numpy as np
-import skimage
+import skimage.measure
+import skimage.transform
 import tensorflow as tf
 
 from nobrainer import __version__


### PR DESCRIPTION
fixes https://github.com/neuronets/nobrainer/issues/75

import `skimage.measure` and `skimage.transform` explicitly instead of only `skimage`.