### PR TITLE
add `nobrainer info` command

### DIFF
--- a/nobrainer/cli/main.py
+++ b/nobrainer/cli/main.py
@@ -1,9 +1,11 @@
 """Main command-line interface for nobrainer."""
 
+import datetime
 import inspect
 import json
 import logging
 import os
+import platform
 import pprint
 import sys
 
@@ -13,6 +15,7 @@ import numpy as np
 import skimage.measure
 import skimage.transform
 import tensorflow as tf
+import tensorflow_probability as tfp
 
 from nobrainer import __version__
 from nobrainer.io import verify_features_labels as _verify_features_labels
@@ -257,6 +260,30 @@ def evaluate():
     """Evaluate a model's predictions against known labels."""
     click.echo("Not implemented yet. In the future, this command will be used for evaluation.")
     sys.exit(-2)
+
+
+@cli.command()
+def info():
+    """Return information about this system."""
+    uname = platform.uname()
+    s = f"""\
+Python:
+  Version: {platform.python_version()}
+  Implementation: {platform.python_implementation()}
+  64-bit: {sys.maxsize > 2**32}
+  Packages:
+    Nobrainer: {__version__}
+    Nibabel: {nib.__version__}
+    Numpy: {np.__version__}
+    TensorFlow: {tf.__version__}
+    TensorFlow-Probability: {tfp.__version__}
+System:
+  OSType: {uname.system}
+  Release: {uname.release}
+  Version: {uname.version}
+  Architecture: {uname.machine}
+Timestamp: {datetime.datetime.utcnow().strftime('%Y/%m/%d %T')}"""
+    click.echo(s)
 
 
 # For debugging only.

--- a/nobrainer/cli/main.py
+++ b/nobrainer/cli/main.py
@@ -268,20 +268,24 @@ def info():
     uname = platform.uname()
     s = f"""\
 Python:
-  Version: {platform.python_version()}
-  Implementation: {platform.python_implementation()}
-  64-bit: {sys.maxsize > 2**32}
-  Packages:
-    Nobrainer: {__version__}
-    Nibabel: {nib.__version__}
-    Numpy: {np.__version__}
-    TensorFlow: {tf.__version__}
-    TensorFlow-Probability: {tfp.__version__}
+ Version: {platform.python_version()}
+ Implementation: {platform.python_implementation()}
+ 64-bit: {sys.maxsize > 2**32}
+ Packages:
+  Nobrainer: {__version__}
+  Nibabel: {nib.__version__}
+  Numpy: {np.__version__}
+  TensorFlow: {tf.__version__}
+   GPU support: {tf.test.is_built_with_gpu_support()}
+   GPU available: {bool(tf.config.list_physical_devices('GPU'))}
+  TensorFlow-Probability: {tfp.__version__}
+
 System:
-  OSType: {uname.system}
-  Release: {uname.release}
-  Version: {uname.version}
-  Architecture: {uname.machine}
+ OSType: {uname.system}
+ Release: {uname.release}
+ Version: {uname.version}
+ Architecture: {uname.machine}
+
 Timestamp: {datetime.datetime.utcnow().strftime('%Y/%m/%d %T')}"""
     click.echo(s)
 

--- a/nobrainer/cli/tests/main_test.py
+++ b/nobrainer/cli/tests/main_test.py
@@ -124,3 +124,12 @@ def test_save():
 @pytest.mark.xfail
 def test_evaluate():
     assert False
+
+
+def test_info():
+    runner = CliRunner()
+    result = runner.invoke(climain.cli, ["info"])
+    assert result.exit_code == 0
+    assert "Python" in result.output
+    assert "System" in result.output
+    assert "Timestamp" in result.output


### PR DESCRIPTION
This will be useful to collect info from users who submit issues.

Sample output:

```
$ nobrainer info
Python:
  Version: 3.7.6
  Implementation: CPython
  64-bit: True
  Packages:
    Nobrainer: 0.0.2+2.g27fd054
    Nibabel: 3.0.0
    Numpy: 1.18.1
    TensorFlow: 2.1.0
    TensorFlow-Probability: 0.9.0
System:
  OSType: Linux
  Release: 4.19.0-6-amd64
  Version: #1 SMP Debian 4.19.67-2+deb10u2 (2019-11-11)
  Architecture: x86_64
Timestamp: 2020/01/11 15:54:02
```