### PR TITLE
add dockerfile with all dependencies, including jupyter

### DIFF
--- a/docker/big.Dockerfile
+++ b/docker/big.Dockerfile
@@ -1,0 +1,15 @@
+FROM tensorflow/tensorflow:2.1.0-gpu-py3-jupyter
+ARG DEBIAN_FRONTEND="noninteractive"
+RUN apt-get update \
+    && apt-get install --yes --quiet --no-install-recommends \
+        graphviz \
+    && rm -rf /var/lib/apt/lists/* \
+    && pip3 install --no-cache-dir \
+        matplotlib \
+        pandas \
+        pydot \
+        seaborn
+COPY [".", "/opt/nobrainer"]
+RUN pip install --no-cache-dir --editable /opt/nobrainer
+LABEL maintainer="Jakub Kaczmarzyk <jakub.kaczmarzyk@gmail.com>"
+ENTRYPOINT ["nobrainer"]


### PR DESCRIPTION
This dockerfile inherits from an official tensorflow image, which is quite large. Though it is large, using the official image makes deployment much easier, because we are sure tensorflow has been installed in the right way and many of the layers already exist on dockerhub.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Summary
<!--- What does your code do? -->

Adds a dockerfile for use on dockerhub