### PR TITLE
use specific version of cloudpickle to fix import error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ branches:
     - master
 install:
   - python3 -m pip install --upgrade --force-reinstall --no-cache-dir --editable=".[cpu,dev]"
+  - python3 -m pip install --no-cache-dir "cloudpickle==1.3.0"
 script:
   - flake8
   - travis_wait pytest


### PR DESCRIPTION
temporary workaround for https://github.com/tensorflow/probability/issues/991

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Summary
<!--- What does your code do? -->

## Checklist
<!--- Please, let us know if you need help-->
- [ ] All tests passing
- [ ] I have added tests to cover my changes
- [ ] I have updated documentation (if necessary)
- [ ] My code follows the code style of this project
(we are using `black`: you can `pip install pre-commit`,
run `pre-commit install` in the `pydra` directory
and `black` will be run automatically with each commit)

## Acknowledgment
- [ ] I acknowledge that this contribution will be available under the Apache 2 license.
