### PR TITLE
BF: Add block_length param to dataset.interleave

### DIFF
--- a/nobrainer/dataset.py
+++ b/nobrainer/dataset.py
@@ -34,14 +34,26 @@ def tfrecord_dataset(
     # Assume all files have same compression type as the first file.
     compression_type = "GZIP" if compressed else None
     cycle_length = 1 if num_parallel_calls is None else num_parallel_calls
+    parse_fn = parse_example_fn(volume_shape=volume_shape, scalar_label=scalar_label)
+
+    # Determine examples_per_shard from the first TFRecord shard
+    first_shard = (
+        dataset.take(1)
+        .flat_map(
+            lambda x: tf.data.TFRecordDataset(x, compression_type=compression_type)
+        )
+        .map(map_func=parse_fn, num_parallel_calls=num_parallel_calls)
+    )
+    block_length = len([0 for _ in first_shard])
+
     dataset = dataset.interleave(
         map_func=lambda x: tf.data.TFRecordDataset(
             x, compression_type=compression_type
         ),
         cycle_length=cycle_length,
+        block_length=block_length,
         num_parallel_calls=num_parallel_calls,
     )
-    parse_fn = parse_example_fn(volume_shape=volume_shape, scalar_label=scalar_label)
     dataset = dataset.map(map_func=parse_fn, num_parallel_calls=num_parallel_calls)
     return dataset
 

--- a/nobrainer/tests/dataset_test.py
+++ b/nobrainer/tests/dataset_test.py
@@ -1,6 +1,59 @@
+import os.path as op
+import shutil
+import tempfile
+
+import numpy as np
+from numpy.testing import assert_array_equal
 import pytest
 
-from .. import dataset
+from .. import dataset, io, tfrecord, utils
+
+
+@pytest.fixture(scope="session")
+def tmp_data_filepaths():
+    temp_dir = tempfile.mkdtemp()
+    csv_of_filepaths = utils.get_data(cache_dir=temp_dir)
+    filepaths = io.read_csv(csv_of_filepaths)
+    yield filepaths
+    shutil.rmtree(temp_dir)
+
+
+def write_tfrecs(filepaths, outdir, examples_per_shard):
+    tfrecord.write(
+        features_labels=filepaths,
+        filename_template=op.join(outdir, "data_shard-{shard:03d}.tfrec"),
+        examples_per_shard=examples_per_shard,
+    )
+    return op.join(outdir, "data_shard-*.tfrec")
+
+
+@pytest.mark.parametrize("examples_per_shard", [1, 3])
+@pytest.mark.parametrize("batch_size", [1, 2])
+@pytest.mark.parametrize("num_parallel_calls", [1, 2])
+def test_get_dataset_maintains_order(
+    tmp_data_filepaths, examples_per_shard, batch_size, num_parallel_calls
+):
+    filepaths = [(x, i) for i, (x, _) in enumerate(tmp_data_filepaths)]
+    temp_dir = tempfile.mkdtemp()
+    file_pattern = write_tfrecs(
+        filepaths, temp_dir, examples_per_shard=examples_per_shard
+    )
+    volume_shape = (256, 256, 256)
+    dset = dataset.get_dataset(
+        file_pattern=file_pattern,
+        n_classes=1,
+        batch_size=batch_size,
+        volume_shape=volume_shape,
+        scalar_label=True,
+        n_epochs=1,
+        num_parallel_calls=num_parallel_calls,
+    )
+    y_orig = np.array([y for _, y in filepaths])
+    y_from_dset = (
+        np.concatenate([y for _, y in dset.as_numpy_iterator()]).flatten().astype(int)
+    )
+    assert_array_equal(y_orig, y_from_dset)
+    shutil.rmtree(temp_dir)
 
 
 # TODO: need to implement this soon.


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Summary
<!--- What does your code do? -->
Resolves #174 
This PR adds a `block_length` param to the `dataset.interleave` method. `block_length` should be set to the `examples_per_shard` that were used to write the original TFRecords dataset. Without this, `get_data` inadvertently shuffles its input data.

## Checklist
<!--- Please, let us know if you need help-->
- [x] I have added tests to cover my changes
- [ ] I have updated documentation (if necessary)

## Acknowledgment
- [x] I acknowledge that this contribution will be available under the Apache 2 license.
