### PR TITLE
Fix #246: Transforms now return labels if passed

### DIFF
--- a/nobrainer/intensity_transforms.py
+++ b/nobrainer/intensity_transforms.py
@@ -43,8 +43,9 @@ def addGaussianNoise(x, y=None, trans_xy=False, noise_mean=0.0, noise_std=0.1):
 
         y = tf.cast(y, tf.float32)
         return tf.math.add(x, noise), tf.math.add(y, noise)
-    else:
+    if y is None:
         return tf.math.add(x, noise)
+    return tf.math.add(x, noise), y
 
 
 def minmaxIntensityScaling(x, y=None, trans_xy=False):
@@ -90,6 +91,8 @@ def minmaxIntensityScaling(x, y=None, trans_xy=False):
         ymin = tf.cast(tf.reduce_min(y), tf.float32)
         ymax = tf.cast(tf.reduce_max(y), tf.float32)
         y = tf.divide(tf.subtract(y, ymin), tf.add(tf.subtract(ymax, ymin), ep))
+    if y is None:
+        return x
     return x, y
 
 
@@ -151,9 +154,9 @@ def customIntensityScaling(x, y=None, trans_xy=False, scale_x=[0.0, 1.0], scale_
         )
         diff_y = tf.subtract(maxy, miny)
         y = tf.add(tf.multiply(y_norm, diff_y), miny)
-        return x, y
-    else:
+    if y is None:
         return x
+    return x, y
 
 
 def intensityMasking(x, mask_x, y=None, trans_xy=False, mask_y=None):
@@ -206,8 +209,9 @@ def intensityMasking(x, mask_x, y=None, trans_xy=False, mask_y=None):
         if mask_y.shape[0] != y.shape[0] and mask_x.shape[1] != x.shape[1]:
             raise ValueError("Label Masks shape should be same as Label")
         return x, tf.multiply(y, mask_y)
-    else:
+    if y is None:
         return x
+    return x, y
 
 
 def contrastAdjust(x, y=None, trans_xy=False, gamma=1.0):
@@ -265,5 +269,6 @@ def contrastAdjust(x, y=None, trans_xy=False, gamma=1.0):
         y = tf.pow(tf.divide(tf.subtract(y, ymin), tf.add(y_range, ep)), gamma)
         y = tf.add(tf.multiply(y, y_range), ymin)
         return x, y
-    else:
+    if y is None:
         return x
+    return x, y

--- a/nobrainer/spatial_transforms.py
+++ b/nobrainer/spatial_transforms.py
@@ -46,9 +46,9 @@ def centercrop(x, y=None, finesize=64, trans_xy=False):
             y = tf.convert_to_tensor(y)
         y = tf.cast(y, tf.float32)
         y = y[y1 : y1 + th, x1 : x1 + tw, :]
-        return x, y
-    else:
+    if y is None:
         return x
+    return x, y
 
 
 def spatialConstantPadding(x, y=None, trans_xy=False, padding_zyx=[1, 1, 1]):
@@ -98,9 +98,9 @@ def spatialConstantPadding(x, y=None, trans_xy=False, padding_zyx=[1, 1, 1]):
             y = tf.convert_to_tensor(y)
         y = tf.cast(y, tf.float32)
         y = tf.pad(y, padding, "CONSTANT")
-        return x, y
-    else:
+    if y is None:
         return x
+    return x, y
 
 
 def randomCrop(x, y=None, trans_xy=False, cropsize=16):
@@ -142,8 +142,9 @@ def randomCrop(x, y=None, trans_xy=False, cropsize=16):
         stacked = tf.stack([x, y], axis=0)
         cropped = tf.image.random_crop(stacked, [2, cropsize, cropsize, x.shape[2]])
         return cropped[0], cropped[1]
-    else:
+    if y is None:
         return tf.image.random_crop(x, [cropsize, cropsize, x.shape[2]])
+    return tf.image.random_crop(x, [cropsize, cropsize, x.shape[2]]), y
 
 
 def resize(x, y=None, trans_xy=False, size=[32, 32], mode="bicubic"):
@@ -189,9 +190,9 @@ def resize(x, y=None, trans_xy=False, size=[32, 32], mode="bicubic"):
             y = tf.convert_to_tensor(y)
         y = tf.cast(y, tf.float32)
         y = tf.image.resize(y, size, method=mode)
-        return x, y
-    else:
+    if y is None:
         return x
+    return x, y
 
 
 def randomflip_leftright(x, y=None, trans_xy=False):
@@ -234,5 +235,6 @@ def randomflip_leftright(x, y=None, trans_xy=False):
         c = tf.image.random_flip_left_right(c, seed=None)
         split_channel = int(c.shape[0] / 2)
         return c[0:split_channel, :, :], c[split_channel : c.shape[0], :, :]
-    else:
+    if y is None:
         return tf.image.random_flip_left_right(x, seed=None)
+    return tf.image.random_flip_left_right(x, seed=None), y

--- a/nobrainer/tests/test_intensity_transforms.py
+++ b/nobrainer/tests/test_intensity_transforms.py
@@ -89,7 +89,8 @@ def test_intensityMasking():
 
     y = np.random.rand(*x.shape)
     results, y_out = intensity_transforms.intensityMasking(
-        x, mask_x=mask_x, y=y, trans_xy=False)
+        x, mask_x=mask_x, y=y, trans_xy=False
+    )
     results = tf.squeeze(results)
     np.testing.assert_allclose(results.numpy(), expected)
     np.testing.assert_array_equal(y_out, y)
@@ -107,6 +108,8 @@ def test_contrastAdjust():
     np.testing.assert_allclose(expected, results.numpy(), rtol=1e-05)
 
     y = np.random.rand(*x.shape)
-    results, y_out = intensity_transforms.contrastAdjust(x, y, trans_xy=False, gamma=1.5)
+    results, y_out = intensity_transforms.contrastAdjust(
+        x, y, trans_xy=False, gamma=1.5
+    )
     np.testing.assert_allclose(expected, results.numpy(), rtol=1e-05)
     np.testing.assert_array_equal(y_out, y)

--- a/nobrainer/tests/test_intensity_transforms.py
+++ b/nobrainer/tests/test_intensity_transforms.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 import tensorflow as tf
 
 from nobrainer import intensity_transforms

--- a/nobrainer/tests/test_intensity_transforms.py
+++ b/nobrainer/tests/test_intensity_transforms.py
@@ -5,7 +5,6 @@ import tensorflow as tf
 from nobrainer import intensity_transforms
 
 
-@pytest.fixture(scope="session")
 def test_addGaussianNoise():
     shape = (10, 10, 10)
     x = np.ones(shape).astype(np.float32)
@@ -27,31 +26,55 @@ def test_addGaussianNoise():
     assert y_out.shape == y.shape
     assert np.sum(noise_x - noise_y) < 1e-5
 
+    # test sending y, but not transforming it
+    x_out, y_out = intensity_transforms.addGaussianNoise(
+        x, y, trans_xy=False, noise_mean=0.0, noise_std=1
+    )
+    x_out = x_out.numpy()
+    assert x_out.shape == x.shape
+    assert np.sum(x_out - x) != 0
+    assert y_out.shape == y.shape
+    np.testing.assert_array_equal(y_out, y)
+
 
 def test_minmaxIntensityScaling():
     x = np.random.rand(10, 10, 10).astype(np.float32)
     y = np.random.randint(0, 2, size=(10, 10, 10)).astype(np.float32)
-    x, y = intensity_transforms.minmaxIntensityScaling(x, y, trans_xy=True)
-    x_out = x.numpy()
-    y_out = y.numpy()
+    x_out, y_out = intensity_transforms.minmaxIntensityScaling(x, y, trans_xy=True)
+    x_out = x_out.numpy()
+    y_out = y_out.numpy()
     assert x_out.min() - 0.0 < 1e-5
     assert y_out.min() - 0.0 < 1e-5
     assert 1 - x_out.max() < 1e-5
     assert 1 - y_out.max() < 1e-5
 
+    x_out, y_out = intensity_transforms.minmaxIntensityScaling(x, y, trans_xy=False)
+    x_out = x_out.numpy()
+    assert x_out.min() - 0.0 < 1e-5
+    assert 1 - x_out.max() < 1e-5
+    np.testing.assert_array_equal(y_out, y)
+
 
 def test_customIntensityScaling():
     x = np.random.rand(10, 10, 10).astype(np.float32)
     y = np.random.randint(0, 2, size=(10, 10, 10)).astype(np.float32)
-    x, y = intensity_transforms.customIntensityScaling(
+    x_out, y_out = intensity_transforms.customIntensityScaling(
         x, y, trans_xy=True, scale_x=[0, 100], scale_y=[0, 3]
     )
-    x_out = x.numpy()
-    y_out = y.numpy()
+    x_out = x_out.numpy()
+    y_out = y_out.numpy()
     assert x_out.min() - 0.0 < 1e-5
     assert y_out.min() - 0.0 < 1e-5
     assert 100 - x_out.max() < 1e-5
     assert 3 - y_out.max() < 1e-5
+
+    x_out, y_out = intensity_transforms.customIntensityScaling(
+        x, y, trans_xy=False, scale_x=[0, 100], scale_y=[0, 3]
+    )
+    x_out = x_out.numpy()
+    assert x_out.min() - 0.0 < 1e-5
+    assert 100 - x_out.max() < 1e-5
+    np.testing.assert_array_equal(y_out, y)
 
 
 def test_intensityMasking():
@@ -64,6 +87,13 @@ def test_intensityMasking():
     results = tf.squeeze(results)
     np.testing.assert_allclose(results.numpy(), expected)
 
+    y = np.random.rand(*x.shape)
+    results, y_out = intensity_transforms.intensityMasking(
+        x, mask_x=mask_x, y=y, trans_xy=False)
+    results = tf.squeeze(results)
+    np.testing.assert_allclose(results.numpy(), expected)
+    np.testing.assert_array_equal(y_out, y)
+
 
 def test_contrastAdjust():
     gamma = 1.5
@@ -75,3 +105,8 @@ def test_contrastAdjust():
     )
     results = intensity_transforms.contrastAdjust(x, gamma=1.5)
     np.testing.assert_allclose(expected, results.numpy(), rtol=1e-05)
+
+    y = np.random.rand(*x.shape)
+    results, y_out = intensity_transforms.contrastAdjust(x, y, trans_xy=False, gamma=1.5)
+    np.testing.assert_allclose(expected, results.numpy(), rtol=1e-05)
+    np.testing.assert_array_equal(y_out, y)

--- a/nobrainer/tests/test_spatial_transforms.py
+++ b/nobrainer/tests/test_spatial_transforms.py
@@ -17,6 +17,17 @@ def test_centercrop():
     assert x.shape[1] == fine & x.shape[0] == fine & x.shape[2] == shape[2]
     assert y.shape[1] == fine & y.shape[0] == fine & y.shape[2] == shape[2]
 
+    # Test for passing y but not transoforming it
+    shape = (10, 10, 10)
+    x = np.ones(shape).astype(np.float32)
+    y = np.random.randint(0, 2, size=shape).astype(np.float32)
+    fine = int(x.shape[1])
+    x, y_out = transformations.centercrop(x, y, trans_xy=False, finesize=fine)
+    x = x.numpy()
+    # Test for output shapes
+    assert x.shape[1] == fine & x.shape[0] == fine & x.shape[2] == shape[2]
+    np.testing.assert_array_equal(y_out, y)
+
     # test for both x and y
     shape = (10, 10, 10)
     x = np.ones(shape).astype(np.float32)
@@ -119,6 +130,12 @@ def test_spatialConstantPadding():
     np.testing.assert_allclose(x_expected, resultx.numpy())
     np.testing.assert_allclose(y_expected, resulty.numpy())
 
+    resultx, resulty = transformations.spatialConstantPadding(
+        x, y, trans_xy=False, padding_zyx=[0, 2, 2]
+    )
+    np.testing.assert_allclose(x_expected, resultx.numpy())
+    np.testing.assert_array_equal(resulty, y)
+
 
 def test_randomCrop():
     x = np.random.rand(10, 10, 10).astype(np.float32)
@@ -129,6 +146,11 @@ def test_randomCrop():
     assert np.shape(res_y.numpy()) == expected_shape
     assert np.all(np.in1d(np.ravel(res_x), np.ravel(x)))
     assert np.all(np.in1d(np.ravel(res_y), np.ravel(y)))
+
+    res_x, res_y = transformations.randomCrop(x, y, trans_xy=False, cropsize=3)
+    assert np.shape(res_x.numpy()) == expected_shape
+    assert np.all(np.in1d(np.ravel(res_x), np.ravel(x)))
+    np.testing.assert_array_equal(res_y, y)
 
 
 def test_resize():
@@ -141,6 +163,12 @@ def test_resize():
     assert np.shape(results_x.numpy()) == expected_shape
     assert np.shape(results_y.numpy()) == expected_shape
 
+    results_x, results_y = transformations.resize(
+        x, y, trans_xy=False, size=[5, 5], mode="bicubic"
+    )
+    assert np.shape(results_x.numpy()) == expected_shape
+    np.testing.assert_array_equal(results_y, y)
+
 
 def test_randomflip_leftright():
     x = np.random.rand(3, 3, 3).astype(np.float32)
@@ -149,3 +177,8 @@ def test_randomflip_leftright():
     expected_shape = (3, 3, 3)
     assert np.shape(res_x.numpy()) == expected_shape
     assert np.shape(res_y.numpy()) == expected_shape
+
+    res_x, res_y = transformations.randomflip_leftright(x, y, trans_xy=False)
+    expected_shape = (3, 3, 3)
+    assert np.shape(res_x.numpy()) == expected_shape
+    np.testing.assert_array_equal(res_y, y)


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Summary
<!--- What does your code do? -->
Fixes the spatial and intensity transforms to return labels alongside transformed features, even if the labels aren't transformed.

Resolves #246

## Checklist
<!--- Please, let us know if you need help-->
- [x] I have added tests to cover my changes
- [ ] I have updated documentation (if necessary)

## Acknowledgment
- [x] I acknowledge that this contribution will be available under the Apache 2 license.
