### PR TITLE
remove trained models

### DIFF
--- a/docker/cpu.Dockerfile
+++ b/docker/cpu.Dockerfile
@@ -1,21 +1,8 @@
-FROM tensorflow/tensorflow:2.14.0-jupyter
-RUN curl -sSL http://neuro.debian.net/lists/focal.us-nh.full | tee /etc/apt/sources.list.d/neurodebian.sources.list \
-  && export GNUPGHOME="$(mktemp -d)" \
-  && echo "disable-ipv6" >> ${GNUPGHOME}/dirmngr.conf \
-  && (apt-key adv --homedir $GNUPGHOME --recv-keys --keyserver hkp://pgpkeys.eu 0xA5D32F012649A5A9 \
-  || { curl -sSL http://neuro.debian.net/_static/neuro.debian.net.asc | apt-key add -; } ) \
-  && apt-get update \
-  && apt-get install -y git-annex-standalone git \
-  && rm -rf /tmp/*
+FROM tensorflow/tensorflow:2.15.0.post1-jupyter
 COPY [".", "/opt/nobrainer"]
 RUN cd /opt/nobrainer \
     && sed -i 's/tensorflow >=/tensorflow-cpu >=/g' setup.cfg
-RUN python3 -m pip install --no-cache-dir /opt/nobrainer datalad datalad-osf
-RUN git config --global user.email "neuronets@example.com" \
-    && git config --global user.name "Neuronets maintainers"
-RUN datalad clone https://github.com/neuronets/trained-models /models \
-  && cd /models && git-annex enableremote osf-storage \
-  && datalad get -s osf-storage .
+RUN python3 -m pip install --no-cache-dir /opt/nobrainer
 ENV LC_ALL=C.UTF-8 \
     LANG=C.UTF-8
 WORKDIR "/work"

--- a/docker/gpu.Dockerfile
+++ b/docker/gpu.Dockerfile
@@ -1,20 +1,7 @@
-FROM tensorflow/tensorflow:2.14.0-gpu-jupyter
-RUN curl -sSL http://neuro.debian.net/lists/focal.us-nh.full | tee /etc/apt/sources.list.d/neurodebian.sources.list \
-  && export GNUPGHOME="$(mktemp -d)" \
-  && echo "disable-ipv6" >> ${GNUPGHOME}/dirmngr.conf \
-  && (apt-key adv --homedir $GNUPGHOME --recv-keys --keyserver hkp://pgpkeys.eu 0xA5D32F012649A5A9 \
-  || { curl -sSL http://neuro.debian.net/_static/neuro.debian.net.asc | apt-key add -; } ) \
-  && apt-get update \
-  && apt-get install -y git-annex-standalone git \
-  && rm -rf /tmp/*
+FROM tensorflow/tensorflow:2.15.0.post1-gpu-jupyter
 COPY [".", "/opt/nobrainer"]
 RUN cd /opt/nobrainer
-RUN python3 -m pip install --no-cache-dir /opt/nobrainer datalad datalad-osf
-RUN git config --global user.email "neuronets@example.com" \
-    && git config --global user.name "Neuronets maintainers"
-RUN datalad clone https://github.com/neuronets/trained-models /models \
-  && cd /models && git-annex enableremote osf-storage \
-  && datalad get -s osf-storage .
+RUN python3 -m pip install --no-cache-dir /opt/nobrainer \
 ENV LC_ALL=C.UTF-8 \
     LANG=C.UTF-8
 WORKDIR "/work"


### PR DESCRIPTION
Removing trained-models from the docker container, as a result also git-annex and datalad

Some notes on debugging:
- the tensorflow images are built using jammy (22.04)
- git-annex 10.2306 is available from neurodebian for jammy
- datalad get results in an error for one file from OSF (kwyk/bvwn_multi_prior/weights/variables.index) - the md5 object for that file does exist on osf.
- the same issue could exist in nobrainer zoo cli (i would suggest using mamba/conda for that image and installing datalad from conda-forge).
- the current trained-models repo is almost 1G, hence avoiding it can be beneficial.
