### PR TITLE
feat(data): DataSpec validation, Croissant fix, MPS guard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,3 +151,6 @@ data/
 # Model artifacts
 *.pth
 brain_mask_extraction_model/
+
+# Claude Code review artifacts
+.claude/REVIEW.MD/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,3 +128,33 @@ Every plan MUST include a Constitution Check evaluated before research and after
 ```
 
 If speckit is not installed, follow the principles above manually.
+
+## Dependency constraint
+
+Do not add external dependencies unless they are already declared in `setup.cfg` or `pyproject.toml`. Current core deps include: torch, monai, nibabel, numpy, click, zarr, fsspec, joblib, scikit-image, psutil. If you think a new dep is justified, flag it explicitly — do not silently add it.
+
+## MONAI-first rule
+
+Before implementing any data loading, transform, loss, metric, or inference utility, check whether MONAI already provides it. Prefer wrapping MONAI over reimplementing. Check `monai.transforms`, `monai.data`, `monai.inferers`, `monai.losses`, `monai.metrics` before writing new code. If MONAI's version is insufficient, document why in a code comment.
+
+## Read before write
+
+Before modifying any existing module:
+1. Read the module completely. List its implicit assumptions.
+2. Check what MONAI provides that overlaps.
+3. Do not guess function signatures — read the source.
+4. If the module has existing tests, read those too to understand expected behavior.
+
+## Testing philosophy
+
+Every test should fail if the feature is removed. If a test passes regardless of whether your code exists, it's not testing your code.
+
+## Review process
+
+A reviewer subagent runs automatically (via stop hook) when you finish a task. It executes tests, inspects the diff, and writes a verdict to `.claude/reviews/`. If the reviewer blocks:
+1. Read the review file it points to.
+2. Fix every CRITICAL finding.
+3. Address WARNING findings where reasonable.
+4. The hook will re-run on your next stop.
+
+Do not commit until the reviewer passes.

--- a/conftest.py
+++ b/conftest.py
@@ -6,6 +6,28 @@ import pytest
 import torch
 
 
+def _mps_supports_conv3d() -> bool:
+    """Return True if Conv3D works on the MPS backend."""
+    if not (hasattr(torch.backends, "mps") and torch.backends.mps.is_available()):
+        return False
+    try:
+        m = torch.nn.Conv3d(1, 1, 1).to("mps")
+        x = torch.randn(1, 1, 2, 2, 2, device="mps")
+        m(x)
+        return True
+    except RuntimeError:
+        return False
+
+
+# Disable MPS auto-detection when Conv3D is unsupported (PyTorch < 2.3 on
+# Apple Silicon).  Without this, ``nobrainer.gpu.get_device()`` returns MPS
+# and every 3D convolution raises ``RuntimeError: Conv3D is not supported on
+# MPS``.
+if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+    if not _mps_supports_conv3d():
+        torch.backends.mps.is_available = lambda: False  # type: ignore[assignment]
+
+
 def pytest_collection_modifyitems(config, items):
     """Skip tests marked with @pytest.mark.gpu when CUDA is not available."""
     if torch.cuda.is_available():

--- a/nobrainer/cli/main.py
+++ b/nobrainer/cli/main.py
@@ -104,6 +104,12 @@ def cli():
 @click.option(
     "-v", "--verbose", is_flag=True, help="Print progress messages.", **_option_kwds
 )
+@click.option(
+    "--skip-validate",
+    is_flag=True,
+    help="Skip preflight input-file validation.",
+    **_option_kwds,
+)
 def predict(
     *,
     infile,
@@ -117,11 +123,30 @@ def predict(
     n_samples,
     device,
     verbose,
+    skip_validate,
 ):
     """Predict labels from a NIfTI volume using a trained PyTorch model.
 
     The predictions are saved to OUTFILE.
     """
+    # Preflight validation
+    if not skip_validate:
+        from ..data.spec import FileStatus, check_file_presence
+
+        status = check_file_presence(infile)
+        if status == FileStatus.NOT_FOUND:
+            click.echo(click.style(f"ERROR: Input file not found: {infile}", fg="red"))
+            raise SystemExit(1)
+        if status == FileStatus.ANNEX_MISSING:
+            click.echo(
+                click.style(
+                    f"ERROR: Input is a git-annex symlink with missing content.\n"
+                    f"  Run: datalad get {infile}",
+                    fg="red",
+                )
+            )
+            raise SystemExit(1)
+
     if os.path.exists(outfile):
         raise FileExistsError(f"Output file already exists: {outfile}")
 
@@ -271,7 +296,14 @@ def convert_tfrecords(*, input_paths, output_dir, output_format, verbose):
 )
 @click.option("--no-conform", is_flag=True, help="Disable auto-conforming.")
 @click.option("-v", "--verbose", is_flag=True, help="Print progress.")
-def convert_to_zarr(*, output, images, labels, chunk_shape, no_conform, verbose):
+@click.option(
+    "--skip-validate",
+    is_flag=True,
+    help="Skip preflight input-file validation.",
+)
+def convert_to_zarr(
+    *, output, images, labels, chunk_shape, no_conform, verbose, skip_validate
+):
     """Convert NIfTI image+label pairs to a sharded Zarr3 store."""
     from ..datasets.zarr_store import create_zarr_store
 
@@ -282,6 +314,32 @@ def convert_to_zarr(*, output, images, labels, chunk_shape, no_conform, verbose)
             )
         )
         sys.exit(1)
+
+    # Preflight validation
+    if not skip_validate:
+        from ..data.spec import FileStatus, check_file_presence
+
+        missing: list[str] = []
+        annex_missing: list[str] = []
+        for path in (*images, *labels):
+            status = check_file_presence(path)
+            if status == FileStatus.NOT_FOUND:
+                missing.append(path)
+            elif status == FileStatus.ANNEX_MISSING:
+                annex_missing.append(path)
+        if missing:
+            click.echo(click.style("ERROR: Files not found:", fg="red"))
+            for p in missing:
+                click.echo(f"  {p}")
+            sys.exit(1)
+        if annex_missing:
+            click.echo(
+                click.style("ERROR: git-annex symlinks with missing content:", fg="red")
+            )
+            for p in annex_missing:
+                click.echo(f"  {p}")
+            click.echo(f"\n  Run: datalad get {' '.join(annex_missing)}")
+            sys.exit(1)
 
     pairs = list(zip(images, labels))
     chunks = tuple(int(x) for x in chunk_shape.split(","))
@@ -621,6 +679,126 @@ System:
 
 Timestamp: {datetime.datetime.utcnow().strftime('%Y/%m/%d %T')}"""
     click.echo(s)
+
+
+# ---------------------------------------------------------------------------
+# validate / inspect
+# ---------------------------------------------------------------------------
+
+
+@cli.command()
+@click.argument("manifest", type=click.Path(exists=True))
+@click.option("--json", "as_json", is_flag=True, help="Output results as JSON.")
+@click.option("-v", "--verbose", is_flag=True, help="Show per-subject details.")
+def validate(*, manifest, as_json, verbose):
+    """Validate a dataset manifest against its DataSpec contract.
+
+    MANIFEST is the path to a JSON manifest file. Exits non-zero if any
+    errors are found. Warnings alone do not cause a non-zero exit.
+    """
+    import json as _json
+
+    from ..data.spec import DataSpec
+    from ..data.spec import Severity as _Sev
+    from ..data.spec import validate as _validate
+
+    spec = DataSpec.from_json(manifest)
+    findings = _validate(spec)
+
+    if as_json:
+        click.echo(_json.dumps([f.to_dict() for f in findings], indent=2))
+    else:
+        errs = [f for f in findings if f.severity == _Sev.ERROR]
+        warns = [f for f in findings if f.severity == _Sev.WARNING]
+
+        for f in errs:
+            click.echo(click.style(f"ERROR  {f.field}: {f.message}", fg="red"))
+        for f in warns:
+            click.echo(click.style(f"WARN   {f.field}: {f.message}", fg="yellow"))
+
+        if not findings:
+            click.echo(click.style("Validation passed.", fg="green"))
+        else:
+            click.echo(f"\n{len(errs)} error(s), {len(warns)} warning(s).")
+
+    has_errors = any(f.severity == _Sev.ERROR for f in findings)
+    sys.exit(1 if has_errors else 0)
+
+
+@cli.command()
+@click.argument("path", type=click.Path(exists=True))
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON.")
+def inspect(*, path, as_json):
+    """Inspect NIfTI / Zarr files or a dataset manifest.
+
+    PATH may be a JSON manifest, a single NIfTI file, a .zarr store,
+    or a directory containing NIfTI / Zarr files.
+    """
+    import json as _json
+    from pathlib import Path as _Path
+
+    from ..data.spec import inspect_entry
+
+    target = _Path(path)
+    entries: list[dict] = []
+
+    if target.suffix == ".json":
+        with open(target) as fh:
+            manifest = _json.load(fh)
+        base_dir = target.parent
+        for entry in manifest.get("entries", []):
+            for key in ("image", "label"):
+                if key in entry:
+                    p = _Path(entry[key])
+                    if not p.is_absolute():
+                        p = base_dir / p
+                    entries.append(inspect_entry(p))
+    elif target.is_dir():
+        for child in sorted(target.iterdir()):
+            if child.suffix in (".gz", ".nii", ".zarr") or child.suffixes == [
+                ".nii",
+                ".gz",
+            ]:
+                entries.append(inspect_entry(child))
+    else:
+        entries.append(inspect_entry(target))
+
+    if as_json:
+        click.echo(_json.dumps(entries, indent=2))
+    else:
+        counts = {"present": 0, "annex_missing": 0, "not_found": 0}
+        for e in entries:
+            status = e["file_status"]
+            counts[status] = counts.get(status, 0) + 1
+            if status == "present":
+                shape = tuple(e["shape"]) if e["shape"] else "?"
+                spacing = tuple(e["spacing"]) if e["spacing"] else "?"
+                orient = e["orientation"] or "?"
+                size_mb = (
+                    f"{e['file_size_bytes'] / 1_048_576:.1f}MB"
+                    if e["file_size_bytes"]
+                    else "?"
+                )
+                click.echo(
+                    f"{e['path']}  PRESENT  shape={shape}  "
+                    f"spacing={spacing}  orient={orient}  {size_mb}"
+                )
+            elif status == "annex_missing":
+                click.echo(
+                    click.style(
+                        f"{e['path']}  ANNEX_MISSING  "
+                        f"(run: datalad get {e['path']})",
+                        fg="yellow",
+                    )
+                )
+            else:
+                click.echo(click.style(f"{e['path']}  NOT_FOUND", fg="red"))
+        click.echo("---")
+        click.echo(
+            f"{len(entries)} entries: {counts['present']} present, "
+            f"{counts['annex_missing']} annex_missing, "
+            f"{counts['not_found']} not_found"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/nobrainer/data/__init__.py
+++ b/nobrainer/data/__init__.py
@@ -1,0 +1,1 @@
+"""Dataset specifications and static data for nobrainer."""

--- a/nobrainer/data/spec.py
+++ b/nobrainer/data/spec.py
@@ -1,0 +1,520 @@
+"""Dataset specification, validation, and inspection.
+
+Self-contained module — imports only stdlib + nibabel + numpy.
+Does NOT import from ``nobrainer.*`` so it can be used by external
+CI scripts without installing torch/monai.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import enum
+import json
+import logging
+from pathlib import Path
+
+import nibabel as nib
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Enums
+# ---------------------------------------------------------------------------
+
+VALID_AXIS_CODES = frozenset("RLAPIS")
+
+
+class FileStatus(enum.Enum):
+    """Result of a symlink-aware file presence check."""
+
+    PRESENT = "present"
+    ANNEX_MISSING = "annex_missing"
+    NOT_FOUND = "not_found"
+
+
+class Severity(enum.Enum):
+    """Severity level for a validation finding."""
+
+    ERROR = "error"
+    WARNING = "warning"
+
+
+# ---------------------------------------------------------------------------
+# Dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True)
+class ValidationError:
+    """A single validation finding.
+
+    Attributes:
+        field: Dotted path to the offending field, e.g. ``"entries[3].image"``.
+        subject_index: Entry index, or ``None`` for spec-level errors.
+        message: Human-readable description of the problem.
+        severity: ``Severity.ERROR`` or ``Severity.WARNING``.
+    """
+
+    field: str
+    subject_index: int | None
+    message: str
+    severity: Severity
+
+    def to_dict(self) -> dict:
+        """Serialize to a JSON-friendly dict."""
+        return {
+            "field": self.field,
+            "subject_index": self.subject_index,
+            "message": self.message,
+            "severity": self.severity.value,
+        }
+
+
+@dataclasses.dataclass
+class DataSpec:
+    """Dataset manifest contract.
+
+    Attributes:
+        entries: List of ``{"image": path}`` or ``{"image": path, "label": path}``
+            dicts. Mirrors the MONAI-style data dicts used by
+            ``nobrainer.dataset.get_dataset()``.
+        expected_classes: If set, the allowed integer label values.
+        spacing_range: ``(min_mm, max_mm)`` — every voxel spacing axis must
+            fall within this range.
+        orientation: Expected 3-character orientation code (e.g. ``"RAS"``).
+        zarr_chunk_shape: Expected Zarr inner-chunk dimensions.
+        zarr_levels: Expected number of Zarr pyramid levels.
+    """
+
+    entries: list[dict[str, str]] = dataclasses.field(default_factory=list)
+    expected_classes: set[int] | None = None
+    spacing_range: tuple[float, float] | None = None
+    orientation: str | None = None
+    zarr_chunk_shape: tuple[int, ...] | None = None
+    zarr_levels: int | None = None
+
+    # -- Serialization -------------------------------------------------------
+
+    @classmethod
+    def from_json(cls, path: str | Path) -> DataSpec:
+        """Load a manifest JSON file and return a ``DataSpec``.
+
+        Relative entry paths are resolved against the manifest's parent
+        directory.
+        """
+        path = Path(path)
+        with open(path) as fh:
+            raw = json.load(fh)
+
+        base_dir = path.parent
+
+        entries: list[dict[str, str]] = []
+        for entry in raw.get("entries", []):
+            resolved: dict[str, str] = {}
+            for key in ("image", "label"):
+                if key in entry:
+                    p = Path(entry[key])
+                    if not p.is_absolute():
+                        p = base_dir / p
+                    resolved[key] = str(p)
+            entries.append(resolved)
+
+        expected_classes = raw.get("expected_classes")
+        if expected_classes is not None:
+            expected_classes = set(expected_classes)
+
+        spacing_range = raw.get("spacing_range")
+        if spacing_range is not None:
+            spacing_range = tuple(spacing_range)
+
+        zarr_chunk_shape = raw.get("zarr_chunk_shape")
+        if zarr_chunk_shape is not None:
+            zarr_chunk_shape = tuple(zarr_chunk_shape)
+
+        zarr_levels = raw.get("zarr_levels")
+
+        return cls(
+            entries=entries,
+            expected_classes=expected_classes,
+            spacing_range=spacing_range,
+            orientation=raw.get("orientation"),
+            zarr_chunk_shape=zarr_chunk_shape,
+            zarr_levels=zarr_levels,
+        )
+
+    def to_json(self, path: str | Path) -> None:
+        """Write this spec to a JSON manifest file."""
+        data: dict = {"entries": self.entries}
+        if self.expected_classes is not None:
+            data["expected_classes"] = sorted(self.expected_classes)
+        if self.spacing_range is not None:
+            data["spacing_range"] = list(self.spacing_range)
+        if self.orientation is not None:
+            data["orientation"] = self.orientation
+        if self.zarr_chunk_shape is not None:
+            data["zarr_chunk_shape"] = list(self.zarr_chunk_shape)
+        if self.zarr_levels is not None:
+            data["zarr_levels"] = self.zarr_levels
+        with open(path, "w") as fh:
+            json.dump(data, fh, indent=2)
+            fh.write("\n")
+
+
+# ---------------------------------------------------------------------------
+# File-presence helper
+# ---------------------------------------------------------------------------
+
+
+def check_file_presence(path: str | Path) -> FileStatus:
+    """Symlink-aware file presence check.
+
+    Returns:
+        ``FileStatus.PRESENT`` if the file exists and is readable.
+        ``FileStatus.ANNEX_MISSING`` if the path is a symlink whose target
+        does not exist (typical of un-fetched git-annex / DataLad content).
+        ``FileStatus.NOT_FOUND`` if the path does not exist at all.
+    """
+    p = Path(path)
+    if p.is_symlink() and not p.exists():
+        return FileStatus.ANNEX_MISSING
+    if p.exists():
+        return FileStatus.PRESENT
+    return FileStatus.NOT_FOUND
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+def validate(spec: DataSpec) -> list[ValidationError]:
+    """Check a ``DataSpec`` against its constraints.
+
+    Returns a (possibly empty) list of ``ValidationError`` findings.
+    Header-only reads for spacing/orientation; label-data read only when
+    ``expected_classes`` is set.
+    """
+    errors: list[ValidationError] = []
+
+    # -- Phase 1: spec-level checks (no I/O) --------------------------------
+
+    if not spec.entries:
+        errors.append(
+            ValidationError(
+                field="entries",
+                subject_index=None,
+                message="Entries list is empty.",
+                severity=Severity.ERROR,
+            )
+        )
+        return errors  # nothing else to check
+
+    for i, entry in enumerate(spec.entries):
+        if "image" not in entry:
+            errors.append(
+                ValidationError(
+                    field=f"entries[{i}]",
+                    subject_index=i,
+                    message="Entry is missing required 'image' key.",
+                    severity=Severity.ERROR,
+                )
+            )
+
+    if spec.spacing_range is not None:
+        lo, hi = spec.spacing_range
+        if lo <= 0 or hi <= 0:
+            errors.append(
+                ValidationError(
+                    field="spacing_range",
+                    subject_index=None,
+                    message=f"Spacing range values must be positive, got ({lo}, {hi}).",
+                    severity=Severity.ERROR,
+                )
+            )
+        elif lo > hi:
+            errors.append(
+                ValidationError(
+                    field="spacing_range",
+                    subject_index=None,
+                    message=f"Spacing range min ({lo}) > max ({hi}).",
+                    severity=Severity.ERROR,
+                )
+            )
+
+    if spec.orientation is not None:
+        if len(spec.orientation) != 3 or not all(
+            c in VALID_AXIS_CODES for c in spec.orientation.upper()
+        ):
+            errors.append(
+                ValidationError(
+                    field="orientation",
+                    subject_index=None,
+                    message=(
+                        f"Invalid orientation code '{spec.orientation}'. "
+                        f"Expected 3 characters from {{R,L,A,P,I,S}}."
+                    ),
+                    severity=Severity.ERROR,
+                )
+            )
+
+    if spec.zarr_chunk_shape is not None:
+        if any(d <= 0 for d in spec.zarr_chunk_shape):
+            errors.append(
+                ValidationError(
+                    field="zarr_chunk_shape",
+                    subject_index=None,
+                    message="All chunk shape dimensions must be > 0.",
+                    severity=Severity.ERROR,
+                )
+            )
+
+    if spec.zarr_levels is not None and spec.zarr_levels < 1:
+        errors.append(
+            ValidationError(
+                field="zarr_levels",
+                subject_index=None,
+                message=f"zarr_levels must be >= 1, got {spec.zarr_levels}.",
+                severity=Severity.ERROR,
+            )
+        )
+
+    # -- Phase 2 & 3: per-entry file presence + header validation ------------
+
+    for i, entry in enumerate(spec.entries):
+        if "image" not in entry:
+            continue  # already reported in Phase 1
+
+        # Track which files are present so Phase 3 can read them.
+        image_present = _check_entry_file(
+            errors, entry["image"], f"entries[{i}].image", i
+        )
+
+        label_path = entry.get("label")
+        label_present = False
+        if label_path is not None:
+            label_present = _check_entry_file(
+                errors, label_path, f"entries[{i}].label", i
+            )
+
+        # Phase 3: header validation for present files
+        if image_present:
+            _validate_nifti_header(
+                errors, entry["image"], f"entries[{i}].image", i, spec
+            )
+
+        if label_present and spec.expected_classes is not None:
+            _validate_label_classes(
+                errors, label_path, f"entries[{i}].label", i, spec.expected_classes
+            )
+
+    return errors
+
+
+# ---------------------------------------------------------------------------
+# Validation helpers (private)
+# ---------------------------------------------------------------------------
+
+
+def _check_entry_file(
+    errors: list[ValidationError],
+    path: str,
+    field: str,
+    index: int,
+) -> bool:
+    """Check file presence; append errors; return True if PRESENT."""
+    status = check_file_presence(path)
+    if status == FileStatus.NOT_FOUND:
+        errors.append(
+            ValidationError(
+                field=field,
+                subject_index=index,
+                message=f"File does not exist: {path}",
+                severity=Severity.ERROR,
+            )
+        )
+        return False
+    if status == FileStatus.ANNEX_MISSING:
+        errors.append(
+            ValidationError(
+                field=field,
+                subject_index=index,
+                message=(
+                    "File is a git-annex symlink but content is not present "
+                    f"locally. Run: datalad get {path}"
+                ),
+                severity=Severity.ERROR,
+            )
+        )
+        return False
+    return True
+
+
+def _validate_nifti_header(
+    errors: list[ValidationError],
+    path: str,
+    field: str,
+    index: int,
+    spec: DataSpec,
+) -> None:
+    """Read NIfTI header (no full data load) and check spacing/orientation."""
+    try:
+        img = nib.load(path)
+    except Exception as exc:
+        errors.append(
+            ValidationError(
+                field=field,
+                subject_index=index,
+                message=f"Failed to read NIfTI header: {exc}",
+                severity=Severity.ERROR,
+            )
+        )
+        return
+
+    # Spacing check
+    if spec.spacing_range is not None:
+        lo, hi = spec.spacing_range
+        zooms = img.header.get_zooms()[:3]
+        for axis_idx, z in enumerate(zooms):
+            if not (lo <= z <= hi):
+                errors.append(
+                    ValidationError(
+                        field=field,
+                        subject_index=index,
+                        message=(
+                            f"Voxel spacing axis {axis_idx} = {z:.4f} mm "
+                            f"is outside range [{lo}, {hi}]."
+                        ),
+                        severity=Severity.WARNING,
+                    )
+                )
+
+    # Orientation check
+    if spec.orientation is not None:
+        axcodes = "".join(nib.aff2axcodes(img.affine))
+        if axcodes != spec.orientation.upper():
+            errors.append(
+                ValidationError(
+                    field=field,
+                    subject_index=index,
+                    message=(
+                        f"Orientation is '{axcodes}', "
+                        f"expected '{spec.orientation}'."
+                    ),
+                    severity=Severity.WARNING,
+                )
+            )
+
+
+def _validate_label_classes(
+    errors: list[ValidationError],
+    path: str,
+    field: str,
+    index: int,
+    expected_classes: set[int],
+) -> None:
+    """Read label volume data and check for unexpected class values."""
+    try:
+        img = nib.load(path)
+        data = np.asarray(img.dataobj)
+        found = set(np.unique(data).astype(int).tolist())
+        del data  # free memory immediately
+    except Exception as exc:
+        errors.append(
+            ValidationError(
+                field=field,
+                subject_index=index,
+                message=f"Failed to read label data: {exc}",
+                severity=Severity.ERROR,
+            )
+        )
+        return
+
+    unexpected = found - expected_classes
+    if unexpected:
+        errors.append(
+            ValidationError(
+                field=field,
+                subject_index=index,
+                message=(
+                    f"Label contains unexpected classes: {sorted(unexpected)}. "
+                    f"Expected: {sorted(expected_classes)}."
+                ),
+                severity=Severity.WARNING,
+            )
+        )
+
+
+# ---------------------------------------------------------------------------
+# Inspection
+# ---------------------------------------------------------------------------
+
+
+def inspect_entry(path: str | Path) -> dict:
+    """Return a summary dict for a single NIfTI or Zarr file.
+
+    The dict always contains ``"path"`` and ``"file_status"`` keys.
+    Shape, spacing, orientation, dtype, and file_size_bytes are populated
+    only when the file is present and readable.
+    """
+    p = Path(path)
+    status = check_file_presence(p)
+    result: dict = {
+        "path": str(p),
+        "file_status": status.value,
+        "shape": None,
+        "spacing": None,
+        "orientation": None,
+        "dtype": None,
+        "file_size_bytes": None,
+    }
+
+    if status != FileStatus.PRESENT:
+        return result
+
+    # File size (follows symlinks)
+    try:
+        result["file_size_bytes"] = p.stat().st_size
+    except OSError:
+        pass
+
+    # Zarr store
+    suffix = "".join(p.suffixes)
+    if suffix == ".zarr" or p.is_dir():
+        return _inspect_zarr(result, p)
+
+    # NIfTI
+    return _inspect_nifti(result, p)
+
+
+def _inspect_nifti(result: dict, p: Path) -> dict:
+    """Populate result dict from a NIfTI header."""
+    try:
+        img = nib.load(str(p))
+        result["shape"] = list(img.shape[:3])
+        result["spacing"] = [round(float(z), 4) for z in img.header.get_zooms()[:3]]
+        result["orientation"] = "".join(nib.aff2axcodes(img.affine))
+        result["dtype"] = str(img.header.get_data_dtype())
+    except Exception:
+        logger.debug("Could not read NIfTI header for %s", p, exc_info=True)
+    return result
+
+
+def _inspect_zarr(result: dict, p: Path) -> dict:
+    """Populate result dict from Zarr store metadata."""
+    try:
+        import zarr
+
+        store = zarr.open_group(str(p), mode="r")
+        attrs = dict(store.attrs)
+        result["shape"] = attrs.get("volume_shape")
+        result["dtype"] = attrs.get("image_dtype")
+        if "n_levels" in attrs:
+            result["zarr_levels"] = attrs["n_levels"]
+        if "chunk_shape" in attrs:
+            result["zarr_chunk_shape"] = attrs["chunk_shape"]
+        if "n_subjects" in attrs:
+            result["n_subjects"] = attrs["n_subjects"]
+    except Exception:
+        logger.debug("Could not read Zarr metadata for %s", p, exc_info=True)
+    return result

--- a/nobrainer/processing/croissant.py
+++ b/nobrainer/processing/croissant.py
@@ -8,6 +8,44 @@ import json
 from pathlib import Path
 from typing import Any
 
+CROISSANT_CONTEXT = {
+    "@language": "en",
+    "@vocab": "https://schema.org/",
+    "citeAs": "cr:citeAs",
+    "column": "cr:column",
+    "conformsTo": "dct:conformsTo",
+    "cr": "http://mlcommons.org/croissant/",
+    "rai": "http://mlcommons.org/croissant/RAI/",
+    "data": {"@id": "cr:data", "@type": "@json"},
+    "dataType": {"@id": "cr:dataType", "@type": "@vocab"},
+    "dct": "http://purl.org/dc/terms/",
+    "examples": {"@id": "cr:examples", "@type": "@json"},
+    "extract": "cr:extract",
+    "field": "cr:field",
+    "fileProperty": "cr:fileProperty",
+    "fileObject": "cr:fileObject",
+    "fileSet": "cr:fileSet",
+    "format": "cr:format",
+    "includes": "cr:includes",
+    "isLiveDataset": "cr:isLiveDataset",
+    "jsonPath": "cr:jsonPath",
+    "key": "cr:key",
+    "md5": "cr:md5",
+    "parentField": "cr:parentField",
+    "path": "cr:path",
+    "recordSet": "cr:recordSet",
+    "references": "cr:references",
+    "regex": "cr:regex",
+    "repeated": "cr:repeated",
+    "replace": "cr:replace",
+    "samplingRate": "cr:samplingRate",
+    "sc": "https://schema.org/",
+    "separator": "cr:separator",
+    "source": "cr:source",
+    "subField": "cr:subField",
+    "transform": "cr:transform",
+}
+
 
 def _sha256(path: str | Path) -> str:
     """Compute SHA-256 hex digest of a file."""
@@ -53,8 +91,9 @@ def write_model_croissant(
     loss_name = getattr(estimator, "_loss_name", "unknown")
 
     metadata = {
-        "@context": {"@vocab": "http://mlcommons.org/croissant/"},
-        "@type": "cr:Dataset",
+        "@context": CROISSANT_CONTEXT,
+        "@type": "sc:Dataset",
+        "conformsTo": "http://mlcommons.org/croissant/1.0",
         "name": f"nobrainer-{getattr(estimator, 'base_model', 'model')}",
         "description": (
             f"Trained {getattr(estimator, 'base_model', 'model')} model "
@@ -66,6 +105,11 @@ def write_model_croissant(
                 "name": "model.pth",
                 "contentUrl": "model.pth",
                 "encodingFormat": "application/x-pytorch",
+                "sha256": (
+                    _sha256(save_dir / "model.pth")
+                    if (save_dir / "model.pth").exists()
+                    else ""
+                ),
             }
         ],
         "nobrainer:provenance": {
@@ -123,8 +167,9 @@ def write_checkpoint_croissant(
     checkpoint_dir = Path(checkpoint_dir)
 
     metadata = {
-        "@context": {"@vocab": "http://mlcommons.org/croissant/"},
-        "@type": "cr:Dataset",
+        "@context": CROISSANT_CONTEXT,
+        "@type": "sc:Dataset",
+        "conformsTo": "http://mlcommons.org/croissant/1.0",
         "name": f"nobrainer-{type(model).__name__}",
         "description": f"Trained {type(model).__name__} checkpoint via nobrainer",
         "distribution": [
@@ -133,6 +178,11 @@ def write_checkpoint_croissant(
                 "name": "best_model.pth",
                 "contentUrl": "best_model.pth",
                 "encodingFormat": "application/x-pytorch",
+                "sha256": (
+                    _sha256(checkpoint_dir / "best_model.pth")
+                    if (checkpoint_dir / "best_model.pth").exists()
+                    else ""
+                ),
             }
         ],
         "nobrainer:provenance": {
@@ -172,8 +222,9 @@ def write_dataset_croissant(
 ) -> Path:
     """Write Croissant-ML JSON-LD for a Dataset."""
     metadata = {
-        "@context": {"@vocab": "http://mlcommons.org/croissant/"},
-        "@type": "cr:Dataset",
+        "@context": CROISSANT_CONTEXT,
+        "@type": "sc:Dataset",
+        "conformsTo": "http://mlcommons.org/croissant/1.0",
         "name": "nobrainer-dataset",
         "description": "Brain MRI dataset for nobrainer",
         "distribution": [],

--- a/nobrainer/tests/unit/test_croissant.py
+++ b/nobrainer/tests/unit/test_croissant.py
@@ -81,7 +81,7 @@ class TestWriteModelCroissant:
         data = json.loads(out.read_text())
         assert "@context" in data
         assert "@type" in data
-        assert data["@type"] == "cr:Dataset"
+        assert data["@type"] == "sc:Dataset"
 
     def test_required_provenance_fields(self, tmp_path):
         """Provenance must contain all required fields."""
@@ -164,7 +164,7 @@ class TestWriteDatasetCroissant:
         data = json.loads(out.read_text())
         assert "@context" in data
         assert "@type" in data
-        assert data["@type"] == "cr:Dataset"
+        assert data["@type"] == "sc:Dataset"
 
     def test_dataset_info_present(self, tmp_path):
         ds = _make_fake_dataset(tmp_path)

--- a/nobrainer/tests/unit/test_data_spec.py
+++ b/nobrainer/tests/unit/test_data_spec.py
@@ -1,0 +1,397 @@
+"""Tests for nobrainer.data.spec — DataSpec validation and inspection."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from click.testing import CliRunner
+import nibabel as nib
+import numpy as np
+import pytest
+
+from nobrainer.cli.main import cli
+from nobrainer.data.spec import (
+    DataSpec,
+    FileStatus,
+    Severity,
+    ValidationError,
+    check_file_presence,
+    inspect_entry,
+    validate,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_nifti(
+    tmp_path: Path,
+    name: str,
+    shape: tuple[int, ...] = (16, 16, 16),
+    spacing: tuple[float, ...] = (1.0, 1.0, 1.0),
+    label_classes: list[int] | None = None,
+) -> str:
+    """Create a NIfTI file and return its path as a string."""
+    affine = np.diag([*spacing, 1.0])
+    if label_classes is not None:
+        data = np.random.choice(label_classes, size=shape).astype(np.int32)
+    else:
+        data = np.random.rand(*shape).astype(np.float32)
+    path = tmp_path / name
+    nib.save(nib.Nifti1Image(data, affine), str(path))
+    return str(path)
+
+
+def _make_manifest(tmp_path: Path, spec_dict: dict) -> str:
+    """Write a manifest JSON and return its path."""
+    path = tmp_path / "manifest.json"
+    with open(path, "w") as fh:
+        json.dump(spec_dict, fh)
+    return str(path)
+
+
+# ---------------------------------------------------------------------------
+# check_file_presence
+# ---------------------------------------------------------------------------
+
+
+class TestCheckFilePresence:
+    def test_present_file(self, tmp_path: Path) -> None:
+        f = tmp_path / "real.nii.gz"
+        f.write_bytes(b"data")
+        assert check_file_presence(f) == FileStatus.PRESENT
+
+    def test_not_found(self, tmp_path: Path) -> None:
+        assert check_file_presence(tmp_path / "nope.nii.gz") == FileStatus.NOT_FOUND
+
+    def test_annex_missing(self, tmp_path: Path) -> None:
+        link = tmp_path / "annex_file.nii.gz"
+        os.symlink("/nonexistent/.git/annex/objects/xx/yy/data", str(link))
+        assert check_file_presence(link) == FileStatus.ANNEX_MISSING
+
+    def test_valid_symlink(self, tmp_path: Path) -> None:
+        real = tmp_path / "real.nii.gz"
+        real.write_bytes(b"data")
+        link = tmp_path / "link.nii.gz"
+        os.symlink(str(real), str(link))
+        assert check_file_presence(link) == FileStatus.PRESENT
+
+
+# ---------------------------------------------------------------------------
+# ValidationError
+# ---------------------------------------------------------------------------
+
+
+class TestValidationError:
+    def test_frozen(self) -> None:
+        err = ValidationError(
+            field="entries[0].image",
+            subject_index=0,
+            message="bad",
+            severity=Severity.ERROR,
+        )
+        with pytest.raises(AttributeError):
+            err.field = "other"  # type: ignore[misc]
+
+    def test_to_dict(self) -> None:
+        err = ValidationError("f", 1, "msg", Severity.WARNING)
+        d = err.to_dict()
+        assert d == {
+            "field": "f",
+            "subject_index": 1,
+            "message": "msg",
+            "severity": "warning",
+        }
+
+
+# ---------------------------------------------------------------------------
+# DataSpec serialization
+# ---------------------------------------------------------------------------
+
+
+class TestDataSpecSerialization:
+    def test_from_json_roundtrip(self, tmp_path: Path) -> None:
+        img = _make_nifti(tmp_path, "img.nii.gz")
+        lbl = _make_nifti(tmp_path, "lbl.nii.gz", label_classes=[0, 1, 2])
+        spec = DataSpec(
+            entries=[{"image": img, "label": lbl}],
+            expected_classes={0, 1, 2},
+            spacing_range=(0.5, 2.0),
+            orientation="RAS",
+            zarr_chunk_shape=(32, 32, 32),
+            zarr_levels=3,
+        )
+        out = tmp_path / "spec.json"
+        spec.to_json(out)
+        loaded = DataSpec.from_json(out)
+        assert loaded.expected_classes == spec.expected_classes
+        assert loaded.spacing_range == spec.spacing_range
+        assert loaded.orientation == spec.orientation
+        assert loaded.zarr_chunk_shape == spec.zarr_chunk_shape
+        assert loaded.zarr_levels == spec.zarr_levels
+        assert len(loaded.entries) == 1
+
+    def test_relative_paths_resolved(self, tmp_path: Path) -> None:
+        _make_nifti(tmp_path, "sub01.nii.gz")
+        manifest = {"entries": [{"image": "sub01.nii.gz"}]}
+        mpath = _make_manifest(tmp_path, manifest)
+        spec = DataSpec.from_json(mpath)
+        assert Path(spec.entries[0]["image"]).is_absolute()
+
+
+# ---------------------------------------------------------------------------
+# validate()
+# ---------------------------------------------------------------------------
+
+
+class TestValidate:
+    def test_valid_spec_passes(self, tmp_path: Path) -> None:
+        img = _make_nifti(tmp_path, "img.nii.gz")
+        lbl = _make_nifti(tmp_path, "lbl.nii.gz", label_classes=[0, 1, 2])
+        spec = DataSpec(
+            entries=[{"image": img, "label": lbl}],
+            expected_classes={0, 1, 2},
+            spacing_range=(0.5, 1.5),
+            orientation="RAS",
+        )
+        errors = validate(spec)
+        assert errors == []
+
+    def test_empty_entries_error(self) -> None:
+        spec = DataSpec(entries=[])
+        errors = validate(spec)
+        assert len(errors) == 1
+        assert errors[0].severity == Severity.ERROR
+        assert errors[0].field == "entries"
+
+    def test_missing_image_key(self) -> None:
+        spec = DataSpec(entries=[{"label": "/some/path"}])
+        errors = validate(spec)
+        assert any(
+            e.severity == Severity.ERROR and "'image'" in e.message for e in errors
+        )
+
+    def test_missing_file_detected(self, tmp_path: Path) -> None:
+        spec = DataSpec(entries=[{"image": str(tmp_path / "nope.nii.gz")}])
+        errors = validate(spec)
+        assert any(
+            e.severity == Severity.ERROR and "does not exist" in e.message
+            for e in errors
+        )
+
+    def test_annex_missing_detected(self, tmp_path: Path) -> None:
+        link = tmp_path / "annex.nii.gz"
+        os.symlink("/nonexistent/.git/annex/objects/xx/yy/data", str(link))
+        spec = DataSpec(entries=[{"image": str(link)}])
+        errors = validate(spec)
+        assert len(errors) == 1
+        assert errors[0].severity == Severity.ERROR
+        assert "datalad get" in errors[0].message
+        # Must not crash trying to read the header
+
+    def test_annex_present_passes(self, tmp_path: Path) -> None:
+        real = _make_nifti(tmp_path, "real.nii.gz")
+        link = tmp_path / "link.nii.gz"
+        os.symlink(real, str(link))
+        spec = DataSpec(entries=[{"image": str(link)}])
+        errors = validate(spec)
+        assert errors == []
+
+    def test_spacing_mismatch_detected(self, tmp_path: Path) -> None:
+        img = _make_nifti(tmp_path, "wide.nii.gz", spacing=(3.0, 3.0, 3.0))
+        spec = DataSpec(
+            entries=[{"image": img}],
+            spacing_range=(0.5, 2.0),
+        )
+        errors = validate(spec)
+        warnings = [e for e in errors if e.severity == Severity.WARNING]
+        assert len(warnings) >= 1
+        assert any("outside range" in w.message for w in warnings)
+
+    def test_spacing_in_range(self, tmp_path: Path) -> None:
+        img = _make_nifti(tmp_path, "ok.nii.gz", spacing=(1.0, 1.0, 1.0))
+        spec = DataSpec(
+            entries=[{"image": img}],
+            spacing_range=(0.5, 2.0),
+        )
+        errors = validate(spec)
+        assert not any(
+            e.severity == Severity.WARNING and "spacing" in e.message.lower()
+            for e in errors
+        )
+
+    def test_orientation_mismatch(self, tmp_path: Path) -> None:
+        img = _make_nifti(tmp_path, "ras.nii.gz")  # identity affine → RAS
+        spec = DataSpec(
+            entries=[{"image": img}],
+            orientation="LPI",
+        )
+        errors = validate(spec)
+        warnings = [e for e in errors if e.severity == Severity.WARNING]
+        assert any("Orientation" in w.message for w in warnings)
+
+    def test_orientation_match(self, tmp_path: Path) -> None:
+        img = _make_nifti(tmp_path, "ras.nii.gz")  # identity affine → RAS
+        spec = DataSpec(
+            entries=[{"image": img}],
+            orientation="RAS",
+        )
+        errors = validate(spec)
+        assert not any(
+            e.severity == Severity.WARNING and "Orientation" in e.message
+            for e in errors
+        )
+
+    def test_label_class_violation(self, tmp_path: Path) -> None:
+        img = _make_nifti(tmp_path, "img.nii.gz")
+        lbl = _make_nifti(tmp_path, "lbl.nii.gz", label_classes=[0, 1, 2, 99])
+        spec = DataSpec(
+            entries=[{"image": img, "label": lbl}],
+            expected_classes={0, 1, 2},
+        )
+        errors = validate(spec)
+        warnings = [e for e in errors if e.severity == Severity.WARNING]
+        assert any("unexpected classes" in w.message for w in warnings)
+
+    def test_label_classes_match(self, tmp_path: Path) -> None:
+        img = _make_nifti(tmp_path, "img.nii.gz")
+        lbl = _make_nifti(tmp_path, "lbl.nii.gz", label_classes=[0, 1, 2])
+        spec = DataSpec(
+            entries=[{"image": img, "label": lbl}],
+            expected_classes={0, 1, 2},
+        )
+        errors = validate(spec)
+        assert not any("unexpected" in e.message for e in errors)
+
+    def test_invalid_spacing_range(self) -> None:
+        spec = DataSpec(
+            entries=[{"image": "/dummy"}],
+            spacing_range=(2.0, 0.5),
+        )
+        errors = validate(spec)
+        assert any(
+            e.severity == Severity.ERROR and "spacing_range" in e.field for e in errors
+        )
+
+    def test_invalid_chunk_shape(self) -> None:
+        spec = DataSpec(
+            entries=[{"image": "/dummy"}],
+            zarr_chunk_shape=(32, 0, 32),
+        )
+        errors = validate(spec)
+        assert any(
+            e.severity == Severity.ERROR and "zarr_chunk_shape" in e.field
+            for e in errors
+        )
+
+
+# ---------------------------------------------------------------------------
+# inspect_entry
+# ---------------------------------------------------------------------------
+
+
+class TestInspectEntry:
+    def test_present_nifti(self, tmp_path: Path) -> None:
+        img = _make_nifti(tmp_path, "vol.nii.gz", shape=(32, 32, 32))
+        result = inspect_entry(img)
+        assert result["file_status"] == "present"
+        assert result["shape"] == [32, 32, 32]
+        assert result["spacing"] is not None
+        assert result["orientation"] == "RAS"
+        assert result["file_size_bytes"] > 0
+
+    def test_not_found(self, tmp_path: Path) -> None:
+        result = inspect_entry(tmp_path / "nope.nii.gz")
+        assert result["file_status"] == "not_found"
+        assert result["shape"] is None
+
+    def test_annex_missing(self, tmp_path: Path) -> None:
+        link = tmp_path / "annex.nii.gz"
+        os.symlink("/nonexistent/.git/annex/objects/xx", str(link))
+        result = inspect_entry(link)
+        assert result["file_status"] == "annex_missing"
+        assert result["shape"] is None
+
+
+# ---------------------------------------------------------------------------
+# CLI: validate
+# ---------------------------------------------------------------------------
+
+
+class TestCLIValidate:
+    def test_valid_manifest_exit_zero(self, tmp_path: Path) -> None:
+        _make_nifti(tmp_path, "img.nii.gz")
+        manifest = _make_manifest(tmp_path, {"entries": [{"image": "img.nii.gz"}]})
+        runner = CliRunner()
+        result = runner.invoke(cli, ["validate", manifest])
+        assert result.exit_code == 0
+        assert "passed" in result.output.lower()
+
+    def test_invalid_manifest_exit_nonzero(self, tmp_path: Path) -> None:
+        manifest = _make_manifest(
+            tmp_path, {"entries": [{"image": "nonexistent.nii.gz"}]}
+        )
+        runner = CliRunner()
+        result = runner.invoke(cli, ["validate", manifest])
+        assert result.exit_code == 1
+        assert "ERROR" in result.output
+
+    def test_json_output(self, tmp_path: Path) -> None:
+        _make_nifti(tmp_path, "img.nii.gz")
+        manifest = _make_manifest(tmp_path, {"entries": [{"image": "img.nii.gz"}]})
+        runner = CliRunner()
+        result = runner.invoke(cli, ["validate", manifest, "--json"])
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert isinstance(parsed, list)
+
+    def test_annex_missing_shows_datalad_get(self, tmp_path: Path) -> None:
+        link = tmp_path / "annex.nii.gz"
+        os.symlink("/nonexistent/.git/annex/objects/xx", str(link))
+        manifest = _make_manifest(tmp_path, {"entries": [{"image": "annex.nii.gz"}]})
+        runner = CliRunner()
+        result = runner.invoke(cli, ["validate", manifest])
+        assert result.exit_code == 1
+        assert "datalad get" in result.output
+
+
+# ---------------------------------------------------------------------------
+# CLI: inspect
+# ---------------------------------------------------------------------------
+
+
+class TestCLIInspect:
+    def test_single_nifti(self, tmp_path: Path) -> None:
+        img = _make_nifti(tmp_path, "vol.nii.gz")
+        runner = CliRunner()
+        result = runner.invoke(cli, ["inspect", img])
+        assert result.exit_code == 0
+        assert "PRESENT" in result.output
+
+    def test_manifest_json(self, tmp_path: Path) -> None:
+        _make_nifti(tmp_path, "img.nii.gz")
+        manifest = _make_manifest(tmp_path, {"entries": [{"image": "img.nii.gz"}]})
+        runner = CliRunner()
+        result = runner.invoke(cli, ["inspect", manifest])
+        assert result.exit_code == 0
+        assert "1 entries" in result.output
+
+    def test_json_output_has_file_status(self, tmp_path: Path) -> None:
+        img = _make_nifti(tmp_path, "vol.nii.gz")
+        runner = CliRunner()
+        result = runner.invoke(cli, ["inspect", img, "--json"])
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert isinstance(parsed, list)
+        assert parsed[0]["file_status"] == "present"
+
+    def test_directory_scan(self, tmp_path: Path) -> None:
+        _make_nifti(tmp_path, "a.nii.gz")
+        _make_nifti(tmp_path, "b.nii.gz")
+        runner = CliRunner()
+        result = runner.invoke(cli, ["inspect", str(tmp_path)])
+        assert result.exit_code == 0
+        assert "2 entries" in result.output

--- a/nobrainer/tests/unit/test_dataset_builder.py
+++ b/nobrainer/tests/unit/test_dataset_builder.py
@@ -159,7 +159,7 @@ class TestToCroissant:
         data = json.loads(out.read_text())
         assert "@context" in data
         assert "@type" in data
-        assert data["@type"] == "cr:Dataset"
+        assert data["@type"] == "sc:Dataset"
 
     def test_has_dataset_info(self, tmp_path):
         pairs = _make_file_pairs(2, (16, 16, 16), tmp_path)


### PR DESCRIPTION
Closes #374

## Summary

- **DataSpec validation system**: `DataSpec` dataclass with JSON serialization, `validate()` with symlink-aware file checks (DataLad/git-annex), spacing/orientation/label class validation, `inspect_entry()` for NIfTI/Zarr metadata. New CLI commands: `validate`, `inspect`, `--skip-validate` on `predict`/`convert-to-zarr`.
- **Croissant JSON-LD fix**: Replace inline `@context` dicts with official Croissant 1.0 context (`CROISSANT_CONTEXT` constant), fix `@type` to `sc:Dataset`, add `conformsTo` and `sha256` fields required by `mlcroissant` validation.
- **MPS Conv3D guard**: Disable MPS backend in `conftest.py` when Conv3D is unsupported (PyTorch < 2.3 on Apple Silicon).
- **CLAUDE.md**: Development guidelines (dependency constraints, MONAI-first rule, testing philosophy, review process).

## Test plan

- [x] 394 unit tests pass (`pytest nobrainer/tests/unit/ -m "not gpu"`)
- [x] 26 sr-tests pass (`pytest nobrainer/sr-tests/ -m "not gpu"`)
- [x] `python -c "import nobrainer"` succeeds
- [x] Pre-commit hooks pass (black, flake8, isort, codespell)
- [ ] CI unit tests
- [ ] CI GPU tests